### PR TITLE
Wait for cycled service to come online first

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ jobs:
           BASE_URL_ARG: ${{ secrets.BASE_URL_ARG }}
           ENVIRONMENT_ARG: ${{ secrets.ENVIRONMENT_ARG }}
           RETRY_ATTEMPTS: 60
+          RETRY_TIMEOUT: 5
 ```
 
 This action takes three arguments as environmental variables:
@@ -30,6 +31,7 @@ This action takes three arguments as environmental variables:
 - *BASE_URL_ARG:* The base URL for the deployed VoteShield environment. For example, api.voteshield.us
 - *ENVIRONMENT_ARG:* The environment you are authenticating against. For example, `voteshield`.
 - *RETRY_ATTEMPTS:* Optional. The action will try this number of times every second by default to see if the service is available, considering most instances of this being ran will assume a service was cycled somewhere.
+- *RETRY_TIMEOUT:* Optional. Set's the timeout in seconds between retries. Defaults to 2 seconds.
 
 ## Testing
 

--- a/src/vape.py
+++ b/src/vape.py
@@ -11,6 +11,7 @@ DEFAULT_TIMEOUT = 10
 environment = os.environ.get('ENVIRONMENT_ARG')
 base_url = os.environ.get('BASE_URL_ARG')
 retry_attempts = os.environ.get('RETRY_ATTEMPTS', 60)
+retry_timeout = os.environ.get('RETRY_TIMEOUT', 2)
 
 if os.path.exists('apikeys.json'):
     with open('apikeys.json') as json_file:
@@ -29,7 +30,7 @@ for i in range(retry_attempts):
     except Exception as err:
         print("Attempt {0}/{1} error: {2}".format(i + 1, retry_attempts, err))
     if i is not retry_attempts - 1:
-        sleep(1)
+        sleep(retry_timeout)
 
 # This is required because of this:
 # https://github.com/flasgger/flasgger/issues/267
@@ -59,6 +60,7 @@ def bearer_access_token():
     response = r.json()
     return response['access_token']
 
+print(bearer_access_token())
 
 # For now, population and tag routes are excluded.
 #@schema.parametrize(endpoint="^/(?!populations|tags)",)


### PR DESCRIPTION
**What this does:**

Now this test, by default, will wait 60 seconds (attempting every second) to ensure the service comes online. This change was made because usually this is ran once services are cycled, and a 503 will probably be the status code until the services pass their initial health check.

_Side effects:_

N/A

**Questions:**

Is there a more elegant way to do this (like, pure hypothesis or something)? Also, is the hard-coded one second check interval bad?

**Checklist:**

<!-- Check these off in the Pull Request interface. Use the notes section to explain why something doesn't apply -->

- [x] This has been tested locally.
  - Notes:
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes:
- [x] Updated or created relevant documentation.
  - Notes:
- [ ] Added automated tests relevant to this new code.
  - Notes:
