### PR TITLE
Add notable pops and compare to the "Slow Route" list

### DIFF
--- a/src/vape.py
+++ b/src/vape.py
@@ -71,7 +71,9 @@ def test_api(case):
     timeout = {
         ("GET", "/changes"): 60,
         ("GET", "/change_history"): 60,
+        ("GET", "/copmare"): 60,
         ("GET", "/download_population"): 60,
+        ("GET", "/notable_populations"): 60,
         ("GET", "/system/snapshots"): 60
     }.get((case.operation.method.upper(), case.operation.path), DEFAULT_TIMEOUT)
     case.headers = case.headers or {}


### PR DESCRIPTION

**What this does:**

Adds the following to the "Slow Routes" list:
- `/notable_populations`
- `/compare`

Since on the first hit, they are timing out after the default 10 seconds.

![image](https://user-images.githubusercontent.com/64788907/138138395-a095ebc2-0c8e-4546-8462-fe5bae0bac6e.png)


**Questions:**

How on earth can I specify this in Swagger, as opposed to manually blacklisting these problem routes in the tests themselves? I suppose other architectures rely on async http requests somehow, but we need a better way to handle this long term.

**How to test:**

Run this against a brand new environment that has been provisioned without any caching. The sibling internal PR `feature/manual_vapeshield_action` has evidence of this.


**Checklist:**

- [ ] This has been tested locally.
  - Notes:
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes:
- [ ] Updated or created relevant documentation.
  - Notes:
- [ ] Added automated tests relevant to this new code.
  - Notes:
