### PR TITLE
Double dl-pop timeout

### DIFF
--- a/src/vape.py
+++ b/src/vape.py
@@ -72,7 +72,7 @@ def test_api(case):
         ("GET", "/changes"): 60,
         ("GET", "/change_history"): 60,
         ("GET", "/compare"): 60,
-        ("GET", "/download_population"): 60,
+        ("GET", "/download_population"): 120,
         ("GET", "/notable_populations"): 60,
         ("GET", "/system/snapshots"): 60
     }.get((case.operation.method.upper(), case.operation.path), DEFAULT_TIMEOUT)


### PR DESCRIPTION
**What this does:**

Doubles the timeout for download_populations. After doing a lot of testing, it seems like even outside of pipelines the time it takes for this route to respond is _extremely close_ to 60 seconds.


_Side effects:_

Hard coding timeouts to routes isn't ideal, but at this point I want us to get to a pristine point where we are improving on a working schemathesis test.

**How to test:**

1. _deploy a new environment_
2. _execute this step in a workflow_

**Questions:**

I have a budding suspicion that this route's failure causes others to as well... even though it makes zero sense. I'll keep this in mind as I continue to debug.

**Checklist:**


- [ ] This has been tested locally.
  - Notes:
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes:
- [ ] Updated or created relevant documentation.
  - Notes:
- [ ] Added automated tests relevant to this new code.
  - Notes:

