### PR TITLE
Add more context to KeyError

### DIFF
--- a/src/vape.py
+++ b/src/vape.py
@@ -6,6 +6,7 @@ from time import sleep
 import urllib.request
 import schemathesis
 import os
+import logging
 
 DEFAULT_TIMEOUT = 1
 environment = 'goatfield' #os.environ.get('ENVIRONMENT_ARG')
@@ -61,10 +62,10 @@ def bearer_access_token():
     try:
         response['access_token']
     except KeyError:
-        print("There was a problem authenticating to VoteShield, please check your API Key and Parameters.")
+        logging.error("There was a problem authenticating to VoteShield, please check your API Key and Parameters.")
     return response['access_token']
 
-print(bearer_access_token())
+logging.info(bearer_access_token())
 
 # For now, population and tag routes are excluded.
 @schema.parametrize(method="GET",endpoint="^/(?!download_population)")

--- a/src/vape.py
+++ b/src/vape.py
@@ -58,6 +58,10 @@ def bearer_access_token():
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     response = r.json()
+    try:
+        response['access_token']
+    except KeyError:
+        print("There was a problem authenticating to VoteShield, please check your API Key and Parameters.")
     return response['access_token']
 
 print(bearer_access_token())


### PR DESCRIPTION
**What this does:**

There have been a few instances where authentication has failed, and a pretty vague KeyError is all we have to show for it. This adds a little blurb for anyone who's looking at this the first time and scratching their heads.


**How to test:**

1. _Type some gibberish in your apikeys.json_
2. _Run vapeshield in any capacity_

**Checklist:**

<!-- Check these off in the Pull Request interface. Use the notes section to explain why something doesn't apply -->

- [ ] This has been tested locally.
  - Notes:
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes:
- [ ] Updated or created relevant documentation.
  - Notes:
- [ ] Added automated tests relevant to this new code.
  - Notes:

**Other context:**

- Requires dependency update: **NO**
- This is directly related to a pull request in another repo? **NO**
